### PR TITLE
Changes in Presenter, Contract and ControlModel

### DIFF
--- a/src/model/ControlModel.java
+++ b/src/model/ControlModel.java
@@ -23,7 +23,7 @@ public class ControlModel implements Contract.Model {
         return persistenceData;
     }
     
-    public void languageChange(String path) {
+    public void getLanguageChange(String path) {
 		getPersistenceData().loadProperties(path);
 	}
     

--- a/src/presenter/Contract.java
+++ b/src/presenter/Contract.java
@@ -10,7 +10,6 @@ import view.typing.TypingTestPanel;
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Properties;
 
 public interface Contract {
 	public interface Presenter {

--- a/src/presenter/Contract.java
+++ b/src/presenter/Contract.java
@@ -62,5 +62,6 @@ public interface Contract {
         void startCronometer();
         String getTimerString();
         Cronometer getCronometer();
+        void getLanguageChange();
     }
 }

--- a/src/presenter/Contract.java
+++ b/src/presenter/Contract.java
@@ -62,6 +62,6 @@ public interface Contract {
         void startCronometer();
         String getTimerString();
         Cronometer getCronometer();
-        void getLanguageChange();
+        void getLanguageChange(String optionLanguage);
     }
 }

--- a/src/presenter/Presenter.java
+++ b/src/presenter/Presenter.java
@@ -140,7 +140,7 @@ public class Presenter implements ActionListener, KeyListener, Contract.Presente
 
 	// Eventos para el panel de Configuracion
 	public void config() {
-		view.getPrincipalPanel().setSizesFont(controlModel.getPersistenceConfig().getFontSizes());
+		view.getPrincipalPanel().setSizesFont(model.getPersistenceConfig().getFontSizes());
 		view.getPrincipalPanel().showConfig();
 	}
 	public void change() {
@@ -148,13 +148,13 @@ public class Presenter implements ActionListener, KeyListener, Contract.Presente
 		ManagerGeneral managerGeneral = new ManagerGeneral();
 		switch (language) {
 		case "CHANGE TO SPANISH":
-			controlModel.languageChange("ES");
+			model.getLanguageChange("ES");
 			view.closeApp();
 			managerGeneral.run();
 			break;
 
 		case "CAMBIAR A INGLES":
-			controlModel.languageChange("EN");
+			model.getLanguageChange("EN");
 			view.closeApp();
 			managerGeneral.run();
 			break;

--- a/src/presenter/Presenter.java
+++ b/src/presenter/Presenter.java
@@ -14,13 +14,11 @@ public class Presenter implements ActionListener, KeyListener, Contract.Presente
     private Contract.Model model;
     private Contract.View view;
     private String timerString;
-    private ControlModel controlModel;
     private boolean isRunning;
 
     public void run() {
         properties = model.getPersistenceData().getProperties();
         this.timerString = properties.getProperty("timeString");
-        controlModel = new ControlModel();
         keyTyped = new ArrayList<String>();
     }
 

--- a/src/presenter/Presenter.java
+++ b/src/presenter/Presenter.java
@@ -1,17 +1,9 @@
 package presenter;
 
 import model.ControlModel;
-import sun.applet.Main;
-import util.Constants;
-
 import java.awt.event.*;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Properties;
-
-import javax.swing.JOptionPane;
 
 public class Presenter implements ActionListener, KeyListener, Contract.Presenter {
 

--- a/src/presenter/Presenter.java
+++ b/src/presenter/Presenter.java
@@ -2,7 +2,6 @@ package presenter;
 
 import model.time.Cronometer;
 import java.awt.*;
-import model.ControlModel;
 import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Properties;

--- a/src/presenter/Presenter.java
+++ b/src/presenter/Presenter.java
@@ -2,15 +2,10 @@ package presenter;
 
 import model.time.Cronometer;
 import java.awt.*;
-import util.Constants;
+import model.ControlModel;
 import java.awt.event.*;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Properties;
-import javax.swing.JOptionPane;
-import model.ControlModel;
 
 public class Presenter implements ActionListener, KeyListener, Contract.Presenter {
     private int indexTest;


### PR DESCRIPTION
In presenter, the ControlModel instance was deleted and swapped in method calls by model. Imports that were not used were also eliminated.  

In Contract, its added the getLanguageChange method that is called in the Presenter's change method.

In ControlModel, getLanguageChange was modified.